### PR TITLE
fix invalid use of incomplete type ‘class QDebug’

### DIFF
--- a/common-src/jobs/job.cpp
+++ b/common-src/jobs/job.cpp
@@ -10,6 +10,7 @@
 
 #include <QFileInfo>
 #include <QFile>
+#include <QDebug>
 #include <algorithm>
 #include <vapoursynth/VSHelper.h>
 

--- a/common-src/vapoursynth/vapoursynth_script_processor.cpp
+++ b/common-src/vapoursynth/vapoursynth_script_processor.cpp
@@ -9,6 +9,8 @@
 #include <memory>
 #include <functional>
 
+#include <QDebug>
+
 //==============================================================================
 
 void VS_CC frameReady(void *a_pUserData,

--- a/common-src/vapoursynth/vs_script_library.cpp
+++ b/common-src/vapoursynth/vs_script_library.cpp
@@ -5,6 +5,7 @@
 
 #include <QSettings>
 #include <QProcessEnvironment>
+#include <QDebug>
 
 //==============================================================================
 

--- a/vsedit-job-server-watcher/src/jobs/job_edit_dialog.h
+++ b/vsedit-job-server-watcher/src/jobs/job_edit_dialog.h
@@ -2,6 +2,7 @@
 #define JOB_EDIT_DIALOG_H_INCLUDED
 
 #include <ui_job_edit_dialog.h>
+#include <QDebug>
 
 #include "../../../common-src/settings/settings_definitions_core.h"
 


### PR DESCRIPTION
As the title, and gcc complain about that.